### PR TITLE
PC환경에서 width 반응형

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -18,6 +18,7 @@ export default {
 <style lang="scss" scoped>
 #app {
   width: 100vw;
+  max-width: 100%;
   min-height: 100vh;
 }
 </style>


### PR DESCRIPTION

![캡처](https://user-images.githubusercontent.com/14146566/85222375-5d2fe200-b3f5-11ea-9c48-8c3551cf8461.JPG)

뷰포트가 스크롤바 영역도 포함하다 보니 가로 스크롤 바도 발생하덥니다.
아예 `width` 값을 100%로 지정해도 될거같긴한데 따로 이유가 있을수도 있을것 같아 `max-width` 추가는 어떤가 싶습니다.

(제가 빌드했을땐 문제 없었는데 확인부탁드립니다.)

Signed-off-by: kyechan99 <kyechan99@gmail.com>